### PR TITLE
Add tests for RealProductLogic, Yager, Goguen, ReichenbachSigmoidal (refs #11)

### DIFF
--- a/tests/logics/test_logics.py
+++ b/tests/logics/test_logics.py
@@ -11,8 +11,13 @@ from property_driven_ml.logics.fuzzy_logics import (
     GoedelFuzzyLogic,
     LukasiewiczFuzzyLogic,
     KleeneDienesFuzzyLogic,
+    ReichenbachFuzzyLogic,
+    GoguenFuzzyLogic,
+    ReichenbachSigmoidalFuzzyLogic,
+    YagerFuzzyLogic,
 )
 from property_driven_ml.logics.dl2 import DL2
+from property_driven_ml.logics.real_product_logic import RealProductLogic
 from property_driven_ml.logics.stl import STL
 
 
@@ -478,3 +483,308 @@ class TestLogicConsistency:
                 right_side = logic.OR2(logic.NOT(x), logic.NOT(y))
                 # Note: This might not hold exactly for all fuzzy logics
                 # but should be close for many cases
+
+
+class TestRealProductLogic:
+    """Test RealProductLogic.
+
+    RealProductLogic is the real-valued reformulation of product fuzzy
+    logic under the change of variables ``z = -log(t)``, mapping fuzzy
+    truth ``t ∈ (0, 1]`` to penalty ``z ∈ [0, ∞)``. Under this isomorphism
+    product AND becomes sum, probabilistic-sum OR becomes the dual log
+    formula, and standard negation becomes ``-log(1 - exp(-z))``. LEQ
+    follows DL2's relu(x-y) convention.
+    """
+
+    @pytest.fixture
+    def rp_logic(self):
+        return RealProductLogic()
+
+    def test_realproduct_default_name(self, rp_logic):
+        assert rp_logic.name == "RealProduct"
+
+    def test_realproduct_and_is_sum(self, rp_logic):
+        x = torch.tensor([0.3, 1.0, 0.0, 2.5])
+        y = torch.tensor([0.7, 0.5, 1.0, 0.5])
+        assert torch.allclose(rp_logic.AND2(x, y), x + y)
+
+    def test_realproduct_and_identity_at_zero(self, rp_logic):
+        # z=0 corresponds to fuzzy truth=1; AND with truth is the identity.
+        x = torch.tensor([0.3, 1.0, 2.5])
+        zero = torch.zeros_like(x)
+        assert torch.allclose(rp_logic.AND2(x, zero), x)
+
+    def test_realproduct_leq_is_relu_of_difference(self, rp_logic):
+        x = torch.tensor([0.3, 1.0, -0.5, 2.0])
+        y = torch.tensor([0.7, 1.0, 0.0, 1.5])
+        assert torch.allclose(rp_logic.LEQ(x, y), torch.relu(x - y))
+
+    def test_realproduct_not_matches_formula(self, rp_logic):
+        # NOT(z) = -log(1 - exp(-z)). At z=0.5: -log(1 - exp(-0.5)) ≈ 0.933.
+        x = torch.tensor([0.5, 1.0, 2.0])
+        expected = -torch.log(1.0 - torch.exp(-x))
+        assert torch.allclose(rp_logic.NOT(x), expected)
+
+    def test_realproduct_not_is_involution_on_positive_inputs(self, rp_logic):
+        # NOT(NOT(z)) = z is an exact algebraic identity on z > 0:
+        # NOT(-log(1 - e^-z)) = -log(1 - e^(log(1 - e^-z))) = -log(e^-z) = z.
+        z = torch.tensor([0.5, 1.0, 2.0, 5.0])
+        assert torch.allclose(rp_logic.NOT(rp_logic.NOT(z)), z, atol=1e-5)
+
+    def test_realproduct_or_matches_fuzzy_change_of_variables(self, rp_logic):
+        # Under z = -log(t): fuzzy probabilistic-sum OR(t1, t2) = 1-(1-t1)(1-t2).
+        # In z-domain that equals -log((1-t1)(1-t2)) = -log(1 - (1-e^-z1)(1-e^-z2)),
+        # which is exactly what RealProductLogic.OR2 computes.
+        z1 = torch.tensor([0.3, 1.0, 2.0])
+        z2 = torch.tensor([0.5, 0.2, 1.5])
+        t1, t2 = torch.exp(-z1), torch.exp(-z2)
+        fuzzy_or = 1.0 - (1.0 - t1) * (1.0 - t2)
+        expected = -torch.log(fuzzy_or)
+        assert torch.allclose(rp_logic.OR2(z1, z2), expected)
+
+    def test_realproduct_or_identity_at_large_penalty(self, rp_logic):
+        # OR(z, large) should approach z as large -> infty (since large
+        # corresponds to fuzzy false, and t OR false = t).
+        z = torch.tensor([0.3, 1.0, 2.0])
+        large = torch.full_like(z, 30.0)  # exp(-30) ≈ 1e-13, effectively false
+        assert torch.allclose(rp_logic.OR2(z, large), z, atol=1e-5)
+
+    def test_realproduct_variadic_and(self, rp_logic):
+        a = torch.tensor([0.1, 0.2])
+        b = torch.tensor([0.3, 0.5])
+        c = torch.tensor([0.4, 0.1])
+        assert torch.allclose(rp_logic.AND(a, b, c), a + b + c)
+
+    def test_realproduct_gradients_flow(self, rp_logic):
+        x = torch.tensor([0.5, 1.0], requires_grad=True)
+        y = torch.tensor([0.7, 0.3], requires_grad=True)
+        z = torch.tensor([1.0, 2.0], requires_grad=True)
+
+        loss = rp_logic.OR2(rp_logic.AND2(x, y), rp_logic.LEQ(z, x)).sum()
+        loss.backward()
+        for t in (x, y, z):
+            assert t.grad is not None
+            assert torch.all(torch.isfinite(t.grad))
+
+
+class TestYagerFuzzyLogic:
+    """Test YagerFuzzyLogic (parameterized t-norm interpolating between
+    Łukasiewicz at p=1 and Gödel as p → ∞)."""
+
+    @pytest.fixture
+    def yager(self):
+        return YagerFuzzyLogic()
+
+    def test_yager_name_and_default_p(self, yager):
+        assert yager.name == "YG"
+        assert yager.p == 5
+
+    def test_yager_and_or_in_unit_interval(self, yager):
+        x = torch.tensor([0.1, 0.5, 0.7, 0.9])
+        y = torch.tensor([0.4, 0.2, 0.6, 0.8])
+        for result in (yager.AND(x, y), yager.OR(x, y)):
+            assert torch.all(result >= 0.0)
+            assert torch.all(result <= 1.0)
+
+    def test_yager_and_with_zero_is_zero(self, yager):
+        # False is absorbing for AND. This direction works fine because
+        # (1-x)^p is bounded; only the all-ones direction hits the eps clamp
+        # (see test_yager_and_at_full_truth_saturates_due_to_eps_clamp).
+        x = torch.tensor([0.3, 0.7, 1.0])
+        assert torch.allclose(yager.AND(x, torch.zeros_like(x)), torch.zeros_like(x))
+
+    def test_yager_and_at_full_truth_saturates_due_to_eps_clamp(self):
+        """Pins a numerical limitation in YagerFuzzyLogic.AND tracked as
+        issue #11 (same bug class as #9 in LeakyLogic). The source clamps
+        the inner ``sum((1-x)^p)`` to ``eps=1e-6`` before taking the p-th
+        root, so for inputs of all 1.0 (where the inner sum is exactly 0)
+        the result is ``1 - eps^(1/p)`` instead of the t-norm identity 1.
+        For default ``p=5`` that's ``1 - (1e-6)^0.2 ≈ 0.937``; gets worse as
+        ``p`` grows (``1 - (1e-6)^0.05 ≈ 0.499`` at ``p=20``).
+        """
+        ones = torch.ones(3)
+        for p in (5, 10, 20):
+            expected = 1.0 - (1e-6) ** (1.0 / p)
+            assert torch.allclose(
+                YagerFuzzyLogic(p=p).AND(ones, ones),
+                torch.full_like(ones, expected),
+                atol=1e-5,
+            )
+
+    def test_yager_or_extremes(self, yager):
+        x = torch.tensor([0.3, 0.7, 0.0])
+        # OR with 1 is 1 (true is absorbing for OR).
+        assert torch.allclose(yager.OR(x, torch.ones_like(x)), torch.ones_like(x))
+        # OR of all 0s is 0.
+        zeros = torch.zeros_like(x)
+        assert torch.allclose(yager.OR(zeros, zeros), zeros)
+
+    def test_yager_matches_lukasiewicz_at_p_equals_1(self):
+        # Yager with p=1 reduces to Łukasiewicz: AND = max(0, x+y-1),
+        # OR = min(1, x+y). Both directly from the p-norm formulas at p=1.
+        y_logic = YagerFuzzyLogic(p=1)
+        l_logic = LukasiewiczFuzzyLogic()
+        x = torch.tensor([0.3, 0.7, 0.5, 0.9])
+        y = torch.tensor([0.4, 0.5, 0.8, 0.2])
+        assert torch.allclose(y_logic.AND(x, y), l_logic.AND(x, y), atol=1e-6)
+        assert torch.allclose(y_logic.OR(x, y), l_logic.OR(x, y), atol=1e-6)
+
+    def test_yager_converges_to_godel_as_p_grows(self):
+        # As p -> infty Yager AND/OR approach min/max (Gödel limit).
+        x = torch.tensor([0.6, 0.7, 0.8, 0.5])
+        y = torch.tensor([0.5, 0.8, 0.6, 0.9])
+        and_p2 = YagerFuzzyLogic(p=2).AND(x, y)
+        and_p10 = YagerFuzzyLogic(p=10).AND(x, y)
+        or_p2 = YagerFuzzyLogic(p=2).OR(x, y)
+        or_p10 = YagerFuzzyLogic(p=10).OR(x, y)
+        hard_min = torch.minimum(x, y)
+        hard_max = torch.maximum(x, y)
+        assert torch.all((and_p10 - hard_min).abs() <= (and_p2 - hard_min).abs())
+        assert torch.all((or_p10 - hard_max).abs() <= (or_p2 - hard_max).abs())
+
+    def test_yager_impl_zero_zero_special_case(self, yager):
+        # The 0^0 indeterminate form is explicitly forced to 1 in the source.
+        zero = torch.tensor([0.0])
+        assert torch.allclose(yager.IMPL(zero, zero), torch.ones_like(zero))
+
+    def test_yager_impl_general_formula(self, yager):
+        # IMPL(x, y) = y^x for x, y > 0.
+        x = torch.tensor([0.3, 0.5, 0.8])
+        y = torch.tensor([0.4, 0.6, 0.9])
+        assert torch.allclose(yager.IMPL(x, y), torch.pow(y, x))
+
+    def test_yager_leq_returns_one_at_satisfied(self, yager):
+        # Where x <= y, LEQ is forced to 1 (fully satisfied).
+        x = torch.tensor([0.2, 0.5, 0.7])
+        y = torch.tensor([0.5, 0.5, 0.8])
+        leq = yager.LEQ(x, y)
+        assert torch.allclose(leq, torch.ones_like(leq))
+
+    def test_yager_gradients_flow(self, yager):
+        x = torch.tensor([0.3, 0.7], requires_grad=True)
+        y = torch.tensor([0.5, 0.4], requires_grad=True)
+        loss = yager.AND(x, y).sum() + yager.OR(x, y).sum()
+        loss.backward()
+        for t in (x, y):
+            assert t.grad is not None
+            assert torch.all(torch.isfinite(t.grad))
+
+
+class TestGoguenFuzzyLogic:
+    """Test GoguenFuzzyLogic. Inherits Reichenbach's product AND and
+    probabilistic-sum OR; only overrides IMPL with the R-implication
+    based on the product residuum (``y/x`` for ``x > y``, else 1)."""
+
+    @pytest.fixture
+    def goguen(self):
+        return GoguenFuzzyLogic()
+
+    def test_goguen_name(self, goguen):
+        assert goguen.name == "GG"
+
+    def test_goguen_inherits_reichenbach_and(self, goguen):
+        rc = ReichenbachFuzzyLogic()
+        x = torch.tensor([0.3, 0.7, 0.5])
+        y = torch.tensor([0.5, 0.4, 0.8])
+        assert torch.allclose(goguen.AND(x, y), rc.AND(x, y))
+
+    def test_goguen_inherits_reichenbach_or(self, goguen):
+        rc = ReichenbachFuzzyLogic()
+        x = torch.tensor([0.3, 0.7, 0.5])
+        y = torch.tensor([0.5, 0.4, 0.8])
+        assert torch.allclose(goguen.OR(x, y), rc.OR(x, y))
+
+    def test_goguen_impl_returns_one_when_x_leq_y(self, goguen):
+        x = torch.tensor([0.3, 0.5, 0.0])
+        y = torch.tensor([0.7, 0.5, 0.4])
+        impl = goguen.IMPL(x, y)
+        assert torch.allclose(impl, torch.ones_like(impl))
+
+    def test_goguen_impl_is_ratio_when_x_greater_than_y(self, goguen):
+        # IMPL(0.8, 0.4) = 0.4 / 0.8 = 0.5; IMPL(0.6, 0.3) = 0.5.
+        x = torch.tensor([0.8, 0.6, 0.9])
+        y = torch.tensor([0.4, 0.3, 0.45])
+        assert torch.allclose(goguen.IMPL(x, y), y / x)
+
+    def test_goguen_impl_zero_antecedent_special_case(self, goguen):
+        # x == 0 is explicitly forced to 1 to avoid 0/0.
+        zero = torch.zeros(3)
+        y = torch.tensor([0.0, 0.5, 1.0])
+        assert torch.allclose(goguen.IMPL(zero, y), torch.ones_like(zero))
+
+    def test_goguen_impl_gradients_flow(self, goguen):
+        x = torch.tensor([0.8, 0.5], requires_grad=True)
+        y = torch.tensor([0.3, 0.7], requires_grad=True)
+        loss = goguen.IMPL(x, y).sum()
+        loss.backward()
+        for t in (x, y):
+            assert t.grad is not None
+            assert torch.all(torch.isfinite(t.grad))
+
+
+class TestReichenbachSigmoidalFuzzyLogic:
+    """Test ReichenbachSigmoidalFuzzyLogic (RCS). Inherits Reichenbach
+    AND/OR; replaces the SN-implication with a sigmoidal reshape
+    parameterized by s. The sigmoid is calibrated so that the three
+    anchor points {I=0, I=0.5, I=1} of the underlying Reichenbach IMPL
+    are preserved; higher s sharpens the transition between them."""
+
+    @pytest.fixture
+    def rcs(self):
+        return ReichenbachSigmoidalFuzzyLogic()
+
+    def test_rcs_name_and_default_s(self, rcs):
+        assert rcs.name == "RCS"
+        assert rcs.s == 9.0
+
+    def test_rcs_inherits_reichenbach_and(self, rcs):
+        rc = ReichenbachFuzzyLogic()
+        x = torch.tensor([0.3, 0.7, 0.5])
+        y = torch.tensor([0.5, 0.4, 0.8])
+        assert torch.allclose(rcs.AND(x, y), rc.AND(x, y))
+
+    def test_rcs_inherits_reichenbach_or(self, rcs):
+        rc = ReichenbachFuzzyLogic()
+        x = torch.tensor([0.3, 0.7, 0.5])
+        y = torch.tensor([0.5, 0.4, 0.8])
+        assert torch.allclose(rcs.OR(x, y), rc.OR(x, y))
+
+    def test_rcs_impl_bounded_above_by_one(self, rcs):
+        x = torch.tensor([0.1, 0.3, 0.7, 0.9])
+        y = torch.tensor([0.2, 0.8, 0.4, 0.6])
+        assert torch.all(rcs.IMPL(x, y) <= 1.0 + 1e-6)
+
+    def test_rcs_impl_boundary_cases(self, rcs):
+        # Reichenbach IMPL = 1 - x + x*y. Anchor points where the sigmoid
+        # calibration preserves the value:
+        #   IMPL(0, y) = 1            (false antecedent -> truth)
+        #   IMPL(x, 1) = 1            (true consequent -> truth)
+        #   IMPL(1, 0) = 0            (true -> false)
+        zero = torch.zeros(3)
+        one = torch.ones(3)
+        y_anything = torch.tensor([0.0, 0.5, 1.0])
+        assert torch.allclose(rcs.IMPL(zero, y_anything), torch.ones(3), atol=1e-4)
+        assert torch.allclose(rcs.IMPL(y_anything, one), torch.ones(3), atol=1e-4)
+        assert torch.allclose(rcs.IMPL(one, zero), torch.zeros(3), atol=1e-4)
+
+    def test_rcs_impl_sharpens_with_larger_s(self):
+        # The sigmoid steepens around I=0.5 as s grows: for an underlying
+        # I value below 0.5, larger s pushes the output further toward 0.
+        rcs_low = ReichenbachSigmoidalFuzzyLogic(s=3.0)
+        rcs_high = ReichenbachSigmoidalFuzzyLogic(s=20.0)
+        # Construct (x, y) so that the underlying Reichenbach IMPL is < 0.5:
+        # I(0.9, 0.1) = 1 - 0.9 + 0.9*0.1 = 0.19.
+        x = torch.tensor([0.9])
+        y = torch.tensor([0.1])
+        impl_low = rcs_low.IMPL(x, y)
+        impl_high = rcs_high.IMPL(x, y)
+        assert impl_high < impl_low
+
+    def test_rcs_impl_gradients_flow(self, rcs):
+        x = torch.tensor([0.3, 0.7], requires_grad=True)
+        y = torch.tensor([0.5, 0.4], requires_grad=True)
+        loss = rcs.IMPL(x, y).sum()
+        loss.backward()
+        for t in (x, y):
+            assert t.grad is not None
+            assert torch.all(torch.isfinite(t.grad))


### PR DESCRIPTION
## Summary

Adds tests for the four logics that still had zero or partial coverage after #10: `RealProductLogic`, `YagerFuzzyLogic`, `GoguenFuzzyLogic`, `ReichenbachSigmoidalFuzzyLogic`. +35 tests total. Surfaces a second saturation bug (this time in `YagerFuzzyLogic.AND`) and pins it to a fresh issue (#11).

## Coverage impact

| Module | Before | After |
|---|---:|---:|
| `logics/fuzzy_logics.py` | 67% | 95% |
| `logics/real_product_logic.py` | 53% | 100% |

(`leaky_logic.py` and `qll.py` are covered by #10 and reach 100% / 96% once that lands.)

## What the new tests assert

**`TestRealProductLogic`** verifies the change-of-variables isomorphism with product fuzzy logic under `z = -log(t)`: AND is sum in z-space, OR matches the log-domain dual of probabilistic sum, NOT is an exact involution on positive inputs (proven algebraically, holds to float precision), OR identity at large penalty, LEQ matches DL2's `relu(x-y)`, gradient flow through compound expressions.

**`TestYagerFuzzyLogic`** covers name/default-p, `[0,1]` range, the absorbing/identity boundary behavior of t-norms (with the caveat below), boundary-case matching of `LukasiewiczFuzzyLogic` at `p=1` (Yager reduces exactly), convergence to Gödel (min/max) as `p` grows, the `IMPL(x, y) = y^x` formula with the `0^0` special case, LEQ-at-satisfied, gradient flow. **One test pins #11**: `AND(1, 1)` returns `1 - eps^(1/p)` instead of `1` (e.g. `0.937` at `p=5`, `0.499` at `p=20`) because the source clamps `sum((1-x)^p)` to `eps=1e-6` before the outer p-th root — same bug class as #9 in LeakyLogic, different file.

**`TestGoguenFuzzyLogic`** verifies the only thing Goguen overrides — its R-implication `y/x` (with `1` when `x <= y` and `1` when `x == 0`) — plus that AND/OR are inherited unchanged from Reichenbach.

**`TestReichenbachSigmoidalFuzzyLogic`** verifies inheritance, that the sigmoid IMPL is bounded above by `1`, the three anchor points where the sigmoidal reshape preserves Reichenbach values exactly (`IMPL(0, y) = 1`, `IMPL(x, 1) = 1`, `IMPL(1, 0) = 0`), monotone sharpening behavior with larger `s`, and gradient flow.

## Issue #11

Filed alongside this PR: `YagerFuzzyLogic.AND violates T(1, 1) = 1 due to eps clamp`. The pattern (`clamp the inner sum, then expose the eps through the inverse operation`) is the same as #9 — both have the same shape of fix (rewrite the offending p-norm in log-domain via `logsumexp`). Happy to send a follow-up PR fixing #11 the same way #10 fixes #9.

## Test plan

- [x] `uv run pytest` — 92 passed locally (was 57 on `main`, +35 from this PR)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] No source files touched (tests-only); no behavior changes
- [x] Branched off `main`, not off the #10 branch — these two PRs can land in either order
