### PR TITLE
Fix YagerFuzzyLogic.AND violating the t-norm boundary axiom T(1,1)=1

### DIFF
--- a/src/property_driven_ml/logics/fuzzy_logics.py
+++ b/src/property_driven_ml/logics/fuzzy_logics.py
@@ -2,7 +2,7 @@ import torch
 
 from .logic import Logic
 
-from ..utils import safe_div, safe_pow
+from ..utils import safe_div, safe_pow, safe_zero
 
 
 class FuzzyLogic(Logic):
@@ -255,18 +255,20 @@ class YagerFuzzyLogic(FuzzyLogic):
 
     def AND(self, *xs: torch.Tensor) -> torch.Tensor:
         """n-ary Yager t-norm."""
-        eps = 1e-6
-
-        z = torch.sum(
-            torch.pow(1.0 - torch.stack(xs, dim=0), self.p),
-            dim=0,
+        # Log-domain p-norm of the complements:
+        #   (sum (1-x_i)^p)^(1/p) == exp(LSE(p log(1-x_i)) / p)
+        # The previous form clamped the inner sum to eps=1e-6, and the clamp
+        # survived the outer p-th root: for all-true inputs the result was
+        # 1 - eps^(1/p) instead of 1, violating the t-norm boundary axiom
+        # T(1, 1) = 1 (issue #11; same bug class as #9). In log domain no
+        # clamp on the sum is needed; safe_zero only guards log(0), and its
+        # effect on the result is bounded by machine eps for every p instead
+        # of eps^(1/p).
+        one_minus = 1.0 - torch.stack(xs, dim=0)
+        root = torch.exp(
+            torch.logsumexp(self.p * torch.log(safe_zero(one_minus)), dim=0) / self.p
         )
-
-        return torch.clamp(
-            1.0 - torch.pow(torch.clamp(z, min=eps), 1.0 / self.p),
-            min=0.0,
-            max=1.0,
-        )
+        return torch.clamp(1.0 - root, min=0.0, max=1.0)
 
     def OR(self, *xs: torch.Tensor) -> torch.Tensor:
         """n-ary Yager t-conorm."""

--- a/tests/logics/test_logics.py
+++ b/tests/logics/test_logics.py
@@ -11,6 +11,7 @@ from property_driven_ml.logics.fuzzy_logics import (
     GoedelFuzzyLogic,
     LukasiewiczFuzzyLogic,
     KleeneDienesFuzzyLogic,
+    YagerFuzzyLogic,
 )
 from property_driven_ml.logics.dl2 import DL2
 from property_driven_ml.logics.stl import STL
@@ -478,3 +479,48 @@ class TestLogicConsistency:
                 right_side = logic.OR2(logic.NOT(x), logic.NOT(y))
                 # Note: This might not hold exactly for all fuzzy logics
                 # but should be close for many cases
+
+
+class TestYagerANDBoundary:
+    """Regression tests for issue #11: YagerFuzzyLogic.AND must satisfy the
+    t-norm boundary axiom T(1, 1) = 1.
+
+    The previous implementation clamped the inner ``sum((1-x)^p)`` to
+    ``eps=1e-6`` before the p-th root, so for all-true inputs it returned
+    ``1 - eps^(1/p)`` instead of 1 (0.937 at the default p=5, 0.499 at
+    p=20). The log-domain rewrite removes the clamp on the sum, so the
+    error is bounded by machine eps for every p.
+    """
+
+    def test_and_at_full_truth_is_one(self):
+        ones = torch.ones(3)
+        for p in (1, 2, 5, 10, 20, 50):
+            result = YagerFuzzyLogic(p=p).AND(ones, ones)
+            assert torch.allclose(result, torch.ones_like(result)), (
+                f"T(1,1) != 1 at p={p}: got {result}"
+            )
+
+    def test_and_identity_with_true(self):
+        # Boundary axiom T(x, 1) = x.
+        x = torch.tensor([0.0, 0.25, 0.5, 0.75, 1.0])
+        result = YagerFuzzyLogic(p=5).AND(x, torch.ones_like(x))
+        assert torch.allclose(result, x, atol=1e-5)
+
+    def test_and_interior_matches_textbook_formula(self):
+        x = torch.tensor([0.2, 0.5, 0.8])
+        y = torch.tensor([0.6, 0.5, 0.9])
+        for p in (2, 5, 10):
+            ref = torch.clamp(1.0 - ((1 - x) ** p + (1 - y) ** p) ** (1.0 / p), min=0.0)
+            assert torch.allclose(YagerFuzzyLogic(p=p).AND(x, y), ref, atol=1e-6)
+
+    def test_and_with_false_is_false(self):
+        # False stays absorbing after the rewrite.
+        x = torch.tensor([0.3, 0.7, 1.0])
+        result = YagerFuzzyLogic(p=5).AND(x, torch.zeros_like(x))
+        assert torch.allclose(result, torch.zeros_like(x))
+
+    def test_and_gradients_finite_at_boundaries(self):
+        x = torch.tensor([0.0, 0.3, 1.0], requires_grad=True)
+        y = torch.tensor([0.5, 0.5, 1.0])
+        YagerFuzzyLogic(p=5).AND(x, y).sum().backward()
+        assert x.grad is not None and torch.all(torch.isfinite(x.grad))


### PR DESCRIPTION
Fixes #11.

YagerFuzzyLogic.AND clamps the inner sum((1-x)^p) to eps=1e-6 before taking the p-th root, and the clamp survives through the root: for inputs of all 1.0 the result is 1 - eps^(1/p) instead of 1 (0.937 at the default p=5, 0.499 at p=20), violating the boundary axiom T(1,1)=1 that defines a t-norm. Full analysis and the saturation table are in #11.

The fix is the same log-domain approach as #10: rewrite the complement p-norm as exp(logsumexp(p log(1-x))/p). No clamp on the inner sum is needed; safe_zero only guards log(0), and its effect on the result is bounded by machine eps for every p, instead of the eps^(1/p) gap that grows as p increases. Interior values agree with the textbook formula, the absorbing-false direction is unchanged, and gradients stay finite at both boundaries; regression tests for all of these are included.

Coordination note with #12: that PR adds test_yager_and_at_full_truth_saturates_due_to_eps_clamp, which pins the buggy behavior and references this issue. Whichever lands second should flip that test to the boundary assertion (this PR's test_and_at_full_truth_is_one is exactly that); happy to rebase either PR accordingly.